### PR TITLE
Handle circumstance during discovery where device.name is None

### DIFF
--- a/pyaranet4/pyaranet4.py
+++ b/pyaranet4/pyaranet4.py
@@ -449,7 +449,7 @@ class Aranet4:
             logging.debug("No MAC address known, starting discovery")
             devices = await BleakScanner.discover()
             for device in devices:
-                if self._magic in device.name:
+                if device.name is not None and self._magic in device.name:
                     logging.info("Found MAC address %s for device %s" % (device.address, device.name))
                     self._address = device.address
 


### PR DESCRIPTION
While running discovery I noticed that bleak can report devices whose device.name is `None`, which trips up this bit of the `_discover()` logic.