### PR TITLE
Fixed a bug where specifying a MAC Address does not work

### DIFF
--- a/pyaranet4/pyaranet4.py
+++ b/pyaranet4/pyaranet4.py
@@ -470,8 +470,7 @@ class Aranet4:
         :param uuid:  UUID of attribute to read from
         :return bytearray:  Returned value
         """
-        if not self._address:
-            await self._discover()
+        await self._discover()
 
         try:
             value = await self._client.read_gatt_char(uuid)


### PR DESCRIPTION
When instantiating the `Aranet4` client class, there is the option to specify a `mac_address` in the constructor. This means the class will connect to this address rather than running auto-disovery to find the aranet4 device.

This currently doesn't work, because the `_client` property is never instantiated when specifying the address manually. You simply receive an error that says `_client of None type does not have a method read_gatt_char()`.

Digging into this, it looks like a simple fix. In the `_read_value()` method, simply always call `self._discover()` regardless of if `self.address` is specified or not. The `_discover()` method already has logic to check for the presence of `self.address` and will skip auto discovery accordingly. It then properly instantiates the `BleakClient` and calls `connect()`.

I've tested this and it works perfect for me.